### PR TITLE
[WIP]商品購入画面で配送先の情報を反映させた

### DIFF
--- a/app/assets/stylesheets/transaction/pay_index.scss
+++ b/app/assets/stylesheets/transaction/pay_index.scss
@@ -111,6 +111,14 @@
       color: #333333;
     }
   }
+  &__user-address-flex{
+    display: flex;
+  }
+  &__user-address-update{
+    padding: 0 3px;
+    text-decoration: none;
+    color: #0099E8;
+  }
   &__table-buy{
     padding-top: 30px;
   }

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -5,6 +5,7 @@ class TransactionsController < ApplicationController
   before_action :set_product
 
   def pay_index
+    @user = current_user
     @top_image = @product.images.first
     @card = @set_card.first
     if @card.blank?

--- a/app/views/transactions/pay_index.html.haml
+++ b/app/views/transactions/pay_index.html.haml
@@ -46,9 +46,51 @@
           .transaction-pay__table-way
             %h3 配送先
             .transaction-pay__table-register
-              %i.fas.fa-plus-circle
-              %span.icon-register
-              登録してください
+              .transaction-pay__user-address
+                - if @user.post_num.blank?
+                  %span.icon-register
+                    = link_to "配送先を登録してください", edit_user_registration_path, class: "transaction-pay__user-address-update"
+                - else
+                  .transaction-pay__user-address
+                    - if @user.post_num.blank?
+                      %span.icon-register
+                      = link_to "郵便番号を登録してください", edit_user_registration_path, class: "transaction-pay__user-address-update"
+                    - else
+                      .transaction-pay__user-address-text
+                        〒
+                        = @user.post_num
+                  .transaction-pay__user-address-flex
+                    - if @user.prefecture.blank?
+                      %span.icon-register
+                      = link_to "都道府県を登録してください", edit_user_registration_path, class: "transaction-pay__user-address-update"
+                    - else
+                      .transaction-pay__user-address-text
+                        = @user.prefecture
+                    - if @user.municipality.blank?
+                      %span.icon-register
+                      = link_to "市区町村を登録してください", edit_user_registration_path, class: "transaction-pay__user-address-update"
+                    - else
+                      .transaction-pay__user-address-text
+                        = @user.municipality
+                    - if @user.address.blank?
+                      %span.icon-register
+                      = link_to "番地を登録してください", edit_user_registration_path, class: "transaction-pay__user-address-update"
+                    - else
+                      .transaction-pay__user-address-text
+                        = @user.address
+                  .transaction-pay__user-address-flex
+                    - if @user.first_name.blank?
+                      %span.icon-register
+                      = link_to "名字を登録してください", edit_user_registration_path, class: "transaction-pay__user-address-update"
+                    - else
+                      .transaction-pay__user-address-text
+                        = @user.first_name
+                    - if @user.last_name.blank?
+                      %span.icon-register
+                      = link_to "名前を登録してください", edit_user_registration_path, class: "transaction-pay__user-address-update"
+                    - else
+                      .transaction-pay__user-address-text
+                        = @user.last_name
           .transaction-pay__table-buy
             = form_tag(action: :pay, method: :post, product_id: @product) do
               %button.transaction-pay__table-buy-button 購入する


### PR DESCRIPTION
# What
商品購入画面で配送先の情報を反映した。
配送先を登録していなかったときは登録画面に遷移させるようにした。

# Why
完了の定義に含まれるため。

[![Image from Gyazo](https://i.gyazo.com/1d634617e5db1a5a7797dd7eb5977310.png)](https://gyazo.com/1d634617e5db1a5a7797dd7eb5977310)