### PR TITLE
[WIP]ユーザー登録画面　画像表示エラー修正

### DIFF
--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -7,7 +7,7 @@
   }
 .user-new
   .user-new__logo
-    %img{src: "/assets/logo/logo.png"}
+    = image_tag "logo/logo.png"
   .user-new__header
     %h2 会員情報入力
   .user-new__main
@@ -64,6 +64,6 @@
         .user-new__field--end
           %p1 「登録」のボタンを押すことにより、利用規約に同意したものとみなします
   .user-new__licence
-    %img{src: "/assets/logo/logo-white.png"}
+    = image_tag "logo/logo-white.png"
     %small © FRIMA, Inc.
   -# = render "devise/shared/links"


### PR DESCRIPTION
# What
ユーザー登録画面　画像表示エラー修正
[![Image from Gyazo](https://i.gyazo.com/774e5375f7a4e7b678379ba7ca264ce6.png)](https://gyazo.com/774e5375f7a4e7b678379ba7ca264ce6)

# Why
header, footerの画像が表示されていなかったため。